### PR TITLE
:ant: fix: make contract location relative to code

### DIFF
--- a/sonar/contracts.py
+++ b/sonar/contracts.py
@@ -111,7 +111,7 @@ class ModelRepository():
         """This contract selects the contract associated with this python interface
         compiles it, and deploys it to a locally hosted (testrpc) blockchain."""
 
-        f = open('/Users/amberedmundson/Laboratory/openmined/PySonar/abis/ModelRepository.abi','r')
+        f = open('../abis/ModelRepository.abi','r')
         abi = json.loads(f.read())
         f.close()
 


### PR DESCRIPTION
The path was absolute so it most likely failed for the rest of the 🌎