### PR TITLE
:page_facing_up: docs: remove reference to IPFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,33 +2,10 @@
 
 > Federated Deep Learning on the Ethereum Blockchain
 
-<!-- TOC depthFrom:2 -->
-
-- [installation](#installation)
-    - [truffle](#truffle)
-    - [ipfs](#ipfs)
-    - [build local libraries](#build-local-libraries)
-- [usage](#usage)
-- [known issues](#known-issues)
-
-<!-- /TOC -->
-
 ### truffle
 
 Truffle is required to compile the contracts in this repo:
 ```npm install -g truffle```
-
-### ipfs
-
-As the network itself is too big to actually host it on the blockchain you need `IPFS` to host the files.
-For installation see the [ipfs installation page](https://dist.ipfs.io/#go-ipfs) or run 
-
-```sh
-brew install ipfs
-```
-
-After installation is complete run `ipfs init` to initialize your local IPFS system.
-
 
 ### compile and deploy local libraries
 


### PR DESCRIPTION
Trying to separate concerns, `Sonar` does not need to know about IPFS so no reason to mention it in the docs ¯\_(ツ)_/¯