### PR TITLE
Feature/avoid global truffle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,2 @@
-
 node_modules/
-package.json
-package-lock.json
 data/

--- a/Dockerfile.testrpc
+++ b/Dockerfile.testrpc
@@ -1,6 +1,5 @@
 FROM node:8-alpine
-RUN npm install -g ethereumjs-testrpc truffle
-COPY truffle.js init_testrpc.sh ./
+COPY package.json truffle.js init_testrpc.sh ./
 COPY contracts/ ./contracts/
 COPY migrations/ ./migrations/
 WORKDIR ./

--- a/README.md
+++ b/README.md
@@ -26,10 +26,9 @@ There are two docker files in this repository. `Dockerfile` creates a plain Sona
 
 ## Manual setup
 
-### truffle
+### Install dependencies
 
-Truffle is required to compile the contracts in this repo:
-```npm install -g truffle```
+```npm install```
 
 ### compile and deploy local libraries
 
@@ -41,8 +40,7 @@ testrpc -a 1000
 
 Then, compile the contracts and load them onto the blockchain.
 ```
-truffle compile
-truffle migrate
+npm run deploy
 ```
 
 You should see output like:

--- a/init_testrpc.sh
+++ b/init_testrpc.sh
@@ -10,7 +10,8 @@ rm -rf ${RPC_FOLDER} && mkdir -p ${RPC_FOLDER}
 
 # install testrpc 
 echo "Installing node dependencies.."
-npm i ethereumjs-testrpc truffle > /dev/null
+npm i
+npm i ethereumjs-testrpc > /dev/null
 
 # start testrpc
 echo "Starting testrpc.."
@@ -24,7 +25,7 @@ node_modules/.bin/truffle compile > /dev/null
 
 echo "Deploy contract to testrpc.."
 # TODO: Figure out how to grep/awk the modelrepository from here..
-truffle migrate
+npm run deploy
 
 echo "Cleanup.."
 kill $PID_RPC

--- a/init_testrpc.sh
+++ b/init_testrpc.sh
@@ -11,7 +11,7 @@ rm -rf ${RPC_FOLDER} && mkdir -p ${RPC_FOLDER}
 # install testrpc 
 echo "Installing node dependencies.."
 npm i > /dev/null
-npm i ethereumjs-testrpc > /dev/null
+npm i -g ethereumjs-testrpc > /dev/null
 
 # start testrpc
 echo "Starting testrpc.."

--- a/init_testrpc.sh
+++ b/init_testrpc.sh
@@ -10,7 +10,7 @@ rm -rf ${RPC_FOLDER} && mkdir -p ${RPC_FOLDER}
 
 # install testrpc 
 echo "Installing node dependencies.."
-npm i
+npm i > /dev/null
 npm i ethereumjs-testrpc > /dev/null
 
 # start testrpc

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "sonar",
+  "version": "0.0.1",
+  "description": "Federated Deep Learning on the Ethereum Blockchain",
+  "private": true,
+  "scripts": {
+    "test": "./node_modules/.bin/truffle test",
+    "deploy": "./node_modules/.bin/truffle migrate"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/OpenMined/Sonar.git"
+  },
+  "engine": {
+    "node": "^8.0.0",
+    "npm": ">5.0.0"
+  },
+  "author": "OpenMined",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/OpenMined/Sonar/issues"
+  },
+  "homepage": "https://github.com/OpenMined/Sonar#readme",
+  "devDependencies": {
+    "truffle": "3.4.9"
+  }
+}


### PR DESCRIPTION
fixes #11 

Avoids the issue where developers use different versions of `truffle`
and abstracts the `truffle` usage away in case we ever want to switch
to something else.

The developer does not need to invoke truffle directly anymore.

Info: As we now use the newest solidity compiler we get some warnings (migration and tests still run). They will be fixed in a subsequent PR