### PR TITLE
Adds debug flag to testrpc command for better debugging of intermitte…

### DIFF
--- a/Dockerfile.testrpc
+++ b/Dockerfile.testrpc
@@ -6,4 +6,4 @@ COPY migrations/ ./migrations/
 WORKDIR ./
 RUN sh init_testrpc.sh
 EXPOSE 8545
-CMD [ "testrpc","--host", "0.0.0.0", "--db","/data/testrpc_persist","--seed","20170812","--accounts","42"]
+CMD [ "testrpc","--host", "0.0.0.0", "--db","/data/testrpc_persist","--seed","20170812","--accounts","42","--debug"]


### PR DESCRIPTION
…nt docker issues.

Everywhere we've been running `testrpc` locally, I've just replaced the `docker-compose.yml` config to use this dockerfile and build it dynamically,

i.e. 
```
  testrpc:
    build:
      context: ../../Sonar/
      dockerfile: Dockerfile.testrpc
```

This should help us debug #13 