### PR TITLE
Testrpc build fix

### DIFF
--- a/Dockerfile.testrpc
+++ b/Dockerfile.testrpc
@@ -5,4 +5,4 @@ COPY migrations/ ./migrations/
 WORKDIR ./
 RUN sh init_testrpc.sh
 EXPOSE 8545
-CMD [ "testrpc","--host", "0.0.0.0", "--db","/data/testrpc_persist","--seed","20170812","--accounts","42","--debug"]
+CMD [ "./node_modules/.bin/testrpc","--host", "0.0.0.0", "--db","/data/testrpc_persist","--seed","20170812","--accounts","42","--debug"]

--- a/init_testrpc.sh
+++ b/init_testrpc.sh
@@ -11,7 +11,6 @@ rm -rf ${RPC_FOLDER} && mkdir -p ${RPC_FOLDER}
 # install testrpc 
 echo "Installing node dependencies.."
 npm i > /dev/null
-npm i -g ethereumjs-testrpc > /dev/null
 
 # start testrpc
 echo "Starting testrpc.."

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/OpenMined/Sonar#readme",
   "devDependencies": {
-    "truffle": "3.4.9"
+    "truffle": "3.4.9",
+    "ethereumjs-testrpc": "^4.0.0"
   }
 }


### PR DESCRIPTION
For some reason, the global install was failing to actually put the required executable in the node_modules/.bin directory. This fixes that issue by adding the package to Sonar's devDependenices instead. 

Also, this will allow us to version control the version of testrpc we use in that image, leading to more stable builds.