### PR TITLE
Feature/spec by example

### DIFF
--- a/contracts/ModelRepository.sol
+++ b/contracts/ModelRepository.sol
@@ -46,7 +46,7 @@ contract ModelRepository {
     }
    }
 
-  function addModel(bytes32[] _weights, uint initial_error, uint target_error) payable returns(uint256 model_index) {
+  function addModel(bytes32[] _weights, uint initial_error, uint target_error) payable {
 
     IPFS memory weights;
     weights.first = _weights[0];
@@ -64,8 +64,6 @@ contract ModelRepository {
     newModel.target_error = target_error;
 
     models.push(newModel);
-
-    return models.length-1;
   }
 
   function evalGradient(uint _gradient_id, uint _new_model_error, bytes32[] _new_weights_addr) returns (bool success) {

--- a/test/modelrepository.js
+++ b/test/modelrepository.js
@@ -1,9 +1,38 @@
 var ModelRepository = artifacts.require('./ModelRepository.sol')
 
-contract('ModelRepository', function(accounts) {
-  it('can be deployed', function() {
-    return ModelRepository.deployed().then(function(instance) {
-      assert.ok(instance !== undefined)
+const hexToString = hexString => {
+  return new Buffer(hexString.replace('0x', ''), 'hex').toString()
+}
+
+contract('ModelRepository', accounts => {
+  const ulyssesTheUser = accounts[0]
+
+  it('allows anyone to add a model', () => {
+    const ipfsHash = 'QmWmyoMoctfbAaiEs2G46gpeUmhqFRDW6KWo64y5r581Vz'
+    const twoPartIpfsHash = [
+      ipfsHash.substring(0, 32),
+      ipfsHash.substr(32) + '0'.repeat(18)
+    ]
+    const bountyInWei = 10000
+    const initialError = 42
+    const targetError = 1337
+
+    let modelRepositoryContract;
+    return ModelRepository.deployed().then(instance => {
+      modelRepositoryContract = instance;
+      return modelRepositoryContract.addModel(twoPartIpfsHash, initialError, targetError, {
+        from: ulyssesTheUser,
+        value: bountyInWei
+      })
+    }).then(() => {
+      return modelRepositoryContract.getModel.call(0)
+    }).then(model => {
+      assert.equal(model[0], ulyssesTheUser, 'owner persisted')
+      assert.equal(model[1], bountyInWei, 'bounty persisted')
+      assert.equal(model[2], initialError, 'initial_error persisted')
+      assert.equal(model[3], targetError, 'target_error persisted')
+      assert.equal(hexToString(model[4][0]), twoPartIpfsHash[0], 'ipfshash persisted')
+      assert.equal(hexToString(model[4][1]), twoPartIpfsHash[1], 'ipfshash persisted')
     })
   })
 })

--- a/test/modelrepository.js
+++ b/test/modelrepository.js
@@ -7,7 +7,7 @@ const hexToString = hexString => {
 contract('ModelRepository', accounts => {
   const ulyssesTheUser = accounts[0]
 
-  it('allows anyone to add a model', () => {
+  it('allows anyone to add a model', async () => {
     const ipfsHash = 'QmWmyoMoctfbAaiEs2G46gpeUmhqFRDW6KWo64y5r581Vz'
     const twoPartIpfsHash = [
       ipfsHash.substring(0, 32),
@@ -17,22 +17,18 @@ contract('ModelRepository', accounts => {
     const initialError = 42
     const targetError = 1337
 
-    let modelRepositoryContract;
-    return ModelRepository.deployed().then(instance => {
-      modelRepositoryContract = instance;
-      return modelRepositoryContract.addModel(twoPartIpfsHash, initialError, targetError, {
+    const modelRepositoryContract = await ModelRepository.deployed();
+    await modelRepositoryContract.addModel(twoPartIpfsHash, initialError, targetError, {
         from: ulyssesTheUser,
         value: bountyInWei
-      })
-    }).then(() => {
-      return modelRepositoryContract.getModel.call(0)
-    }).then(model => {
-      assert.equal(model[0], ulyssesTheUser, 'owner persisted')
-      assert.equal(model[1], bountyInWei, 'bounty persisted')
-      assert.equal(model[2], initialError, 'initial_error persisted')
-      assert.equal(model[3], targetError, 'target_error persisted')
-      assert.equal(hexToString(model[4][0]), twoPartIpfsHash[0], 'ipfshash persisted')
-      assert.equal(hexToString(model[4][1]), twoPartIpfsHash[1], 'ipfshash persisted')
     })
+
+    const model = await modelRepositoryContract.getModel.call(0)
+    assert.equal(model[0], ulyssesTheUser, 'owner persisted')
+    assert.equal(model[1], bountyInWei, 'bounty persisted')
+    assert.equal(model[2], initialError, 'initial_error persisted')
+    assert.equal(model[3], targetError, 'target_error persisted')
+    assert.equal(hexToString(model[4][0]), twoPartIpfsHash[0], 'ipfshash persisted')
+    assert.equal(hexToString(model[4][1]), twoPartIpfsHash[1], 'ipfshash persisted')
   })
 })


### PR DESCRIPTION
Initial test showing how to store a model. Offers a showcase on the #19 discussion.

Additionally:
Return values of non-constant functions can
only be used in the same transaction. e.g. if a
contract calls another contract. otherwise the
caller will get the tx hash and check the state
in a subsequent tx. Thus I have removed the return value.