### PR TITLE
Feature/fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,12 @@ python:
 
 # install server dependencies
 before_install:
-  - "sudo apt-get install musl-dev g++ libgmp3-dev libmpfr-dev libmpc-dev gfortran liblapack-dev ca-certificates"
+  - "sudo apt-get install musl-dev g++ libgmp3-dev libmpfr-dev libmpc-dev gfortran liblapack-dev ca-certificates wget"
   - "pip install numpy"
   - "pip install scipy"
+  - "wget https://dist.ipfs.io/go-ipfs/v0.4.10/go-ipfs_v0.4.10_linux-amd64.tar.gz"
+  - "tar xvfz go-ipfs_v0.4.10_linux-amd64.tar.gz"
+  - "./go-ipfs/ipfs init && ./go-ipfs/ipfs daemon &"
 
 # install dependencies
 install:

--- a/notebooks/Sonar - Decentralized Model Training Simulation (local blockchain).ipynb
+++ b/notebooks/Sonar - Decentralized Model Training Simulation (local blockchain).ipynb
@@ -62,7 +62,6 @@
     "from sonar.contracts import ModelRepository,Model\n",
     "from syft.he.paillier.keys import KeyPair\n",
     "from syft.nn.linear import LinearClassifier\n",
-    "import numpy as np\n",
     "from sklearn.datasets import load_diabetes\n",
     "\n",
     "def get_balance(account):\n",

--- a/notebooks/Sonar - Decentralized Model Training Simulation (local blockchain).ipynb
+++ b/notebooks/Sonar - Decentralized Model Training Simulation (local blockchain).ipynb
@@ -60,6 +60,7 @@
     "import numpy as np\n",
     "import phe as paillier\n",
     "from sonar.contracts import ModelRepository,Model\n",
+    "from sonar.ipfs import IPFS\n",
     "from syft.he.paillier.keys import KeyPair\n",
     "from syft.nn.linear import LinearClassifier\n",
     "from sklearn.datasets import load_diabetes\n",
@@ -105,7 +106,7 @@
     "# the simulation begins\n",
     "\n",
     "# ATTENTION: copy paste the correct address (NOT THE DEFAULT SEEN HERE) from truffle migrate output.\n",
-    "repo = ModelRepository('0x249c008fc4f9c01248f557985f5b5b1aed8eb98f', ipfs_host='ipfs', web3_host='testrpc') # blockchain hosted model repository"
+    "repo = ModelRepository('0x249c008fc4f9c01248f557985f5b5b1aed8eb98f', ipfs=IPFS(host='ipfs'), web3_host='testrpc') # blockchain hosted model repository"
    ]
   },
   {

--- a/sonar/contracts.py
+++ b/sonar/contracts.py
@@ -93,7 +93,8 @@ class ModelRepository():
     giving easy to use python functions around the contract's functionality. It
     currently assumes you're running on a local testrpc Ethereum blockchain."""
 
-    def __init__(self, contract_address, account=None, ipfs=IPFS('127.0.0.1', 5001),
+    def __init__(self, contract_address, account=None,
+                 ipfs=IPFS('127.0.0.1', 5001),
                  web3_host='localhost', web3_port=8545):
         """Creates the base blockchain client object (web3) then
          connects to the Sonar contract.
@@ -189,8 +190,8 @@ class ModelRepository():
 
 class IPFSAddress:
     def from_ethereum(self, two_bytes32_representation):
-        return str(two_bytes32_representation[0] +
-                   two_bytes32_representation[1]).split("\x00")[0]
+        return bytearray.fromhex("".join(two_bytes32_representation)
+                                 .replace("0x", "")).decode().replace("0", "")
 
     def to_ethereum(self, ipfs_hash):
         return [ipfs_hash[0:32], ipfs_hash[32:]]

--- a/sonar/ipfs.py
+++ b/sonar/ipfs.py
@@ -2,7 +2,7 @@ import ipfsapi
 
 
 class IPFS:
-    def __init__(self, host, port):
+    def __init__(self, host='127.0.0.1', port=5001):
         self.ipfs = ipfsapi.connect(host, int(port))
 
     def store(self, obj):

--- a/sonar/ipfs.py
+++ b/sonar/ipfs.py
@@ -1,0 +1,12 @@
+import ipfsapi
+
+
+class IPFS:
+    def __init__(self, host, port):
+        self.ipfs = ipfsapi.connect(host, int(port))
+
+    def store(self, obj):
+        return self.ipfs.add_pyobj(obj)
+
+    def retrieve(self, hash):
+        return self.ipfs.get_pyobj(hash)

--- a/sonar/test_contracts.py
+++ b/sonar/test_contracts.py
@@ -1,14 +1,15 @@
 from sonar.contracts import IPFSAddress
 
 
-def can_transform_ipfs_hash_to_its_ethereum_representation():
+def test_transform_ipfs_hash_to_its_ethereum_representation():
     sample_ipfs_hash = "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG"
     assert IPFSAddress().to_ethereum(sample_ipfs_hash) \
         == ["QmYwAPJzv5CZsnA625s3Xf2nemtYgPpH", "dWEz79ojWnPbdG"]
 
 
-def can_transform_ethereum_representation_of_ipfshash_back_to_ipfshash():
+def test_transform_ethereum_representation_of_ipfshash_back_to_ipfshash():
     sample_ethereum_representation = \
-        "0x516d576d796f4d6f63746662416169457332473436677065556d687146524457"
+        ["0x516d576d796f4d6f63746662416169457332473436677065556d687146524457",
+         "0x364b576f3634793572353831567a303030303030303030303030303030303030"]
     assert IPFSAddress().from_ethereum(sample_ethereum_representation) \
         == "QmWmyoMoctfbAaiEs2G46gpeUmhqFRDW6KWo64y5r581Vz"

--- a/sonar/test_ipfs.py
+++ b/sonar/test_ipfs.py
@@ -2,7 +2,7 @@ from sonar.ipfs import IPFS
 
 
 def test_retrieval_of_stored_obj():
-    storage = IPFS('127.0.0.1', 5001)
+    storage = IPFS(host='127.0.0.1', port=5001)
     obj_to_store = {'foo': 'bar'}
     address = storage.store(obj_to_store)
     retrieved_obj = storage.retrieve(address)

--- a/sonar/test_ipfs.py
+++ b/sonar/test_ipfs.py
@@ -1,0 +1,9 @@
+from sonar.ipfs import IPFS
+
+
+def test_retrieval_of_stored_obj():
+    storage = IPFS('127.0.0.1', 5001)
+    obj_to_store = {'foo': 'bar'}
+    address = storage.store(obj_to_store)
+    retrieved_obj = storage.retrieve(address)
+    assert retrieved_obj == obj_to_store


### PR DESCRIPTION
* improves the ipfs testing story
* adds an abstraction layer to ipfs to make it easier to replace functionality. e.g. `get/add_pyobj` is deprecated. See https://github.com/ipfs/py-ipfs-api/issues/96
* the gradient retrieval did not work because it was being passed the ethereum ipfs representation (e.g. `0x516d576d796f4d6f63746662416169457332473436677065556d6871465244570x364b576f3634793572353831567a303030303030303030303030303030303030`) instead of an ipfs address (e.g. `QmWmyoMoctfbAaiEs2G46gpeUmhqFRDW6KWo64y5r581Vz`)

How did I make sure not to break the full integration story?
(`curl -s https://raw.githubusercontent.com/OpenMined/mine.js/hydrogen/.docker/docker-compose.yml | docker-compose -f - up`)

In my local `mine.js`, i changed https://github.com/OpenMined/mine.js/blob/master/.docker/docker-compose.yml#L16 to

```
image: https://github.com/axelhodler/PySonar.git
```

where the changes of this PR are already applied and ran through the notebook successfully