### PR TITLE
Feature/use modifier

### DIFF
--- a/contracts/ModelRepository.sol
+++ b/contracts/ModelRepository.sol
@@ -40,8 +40,7 @@ contract ModelRepository {
   }
 
   modifier onlyByModelOwner(uint _gradient_id) {
-    Model model = models[grads[_gradient_id].model_id];
-    require(msg.sender == model.owner);
+    require(msg.sender == models[grads[_gradient_id].model_id].owner);
      _;
   }
 

--- a/contracts/ModelRepository.sol
+++ b/contracts/ModelRepository.sol
@@ -39,6 +39,12 @@ contract ModelRepository {
 
   }
 
+  modifier onlyByModelOwner(uint _gradient_id) {
+    Model model = models[grads[_gradient_id].model_id];
+    require(msg.sender == model.owner);
+     _;
+  }
+
   function transferAmount(address reciever, uint amount){
     assert(reciever.send(amount));
   }
@@ -63,10 +69,9 @@ contract ModelRepository {
     models.push(newModel);
   }
 
-  function evalGradient(uint _gradient_id, uint _new_model_error, bytes32[] _new_weights_addr) {
-    // TODO: replace with modifier so that people can't waste gas
+  function evalGradient(uint _gradient_id, uint _new_model_error, bytes32[] _new_weights_addr) onlyByModelOwner(_gradient_id) {
     Model model = models[grads[_gradient_id].model_id];
-    if(grads[_gradient_id].evaluated == false && msg.sender == model.owner) {
+    if(grads[_gradient_id].evaluated == false) {
 
       grads[_gradient_id].new_weights.first = _new_weights_addr[0];
       grads[_gradient_id].new_weights.second = _new_weights_addr[1];

--- a/contracts/ModelRepository.sol
+++ b/contracts/ModelRepository.sol
@@ -45,6 +45,11 @@ contract ModelRepository {
      _;
   }
 
+  modifier onlyIfGradientNotYetEvaluated(uint _gradient_id) {
+    require(grads[_gradient_id].evaluated == false);
+    _;
+  }
+
   function transferAmount(address reciever, uint amount){
     assert(reciever.send(amount));
   }
@@ -69,27 +74,23 @@ contract ModelRepository {
     models.push(newModel);
   }
 
-  function evalGradient(uint _gradient_id, uint _new_model_error, bytes32[] _new_weights_addr) onlyByModelOwner(_gradient_id) {
+  function evalGradient(uint _gradient_id, uint _new_model_error, bytes32[] _new_weights_addr) onlyByModelOwner(_gradient_id) onlyIfGradientNotYetEvaluated(_gradient_id) {
+    grads[_gradient_id].new_weights.first = _new_weights_addr[0];
+    grads[_gradient_id].new_weights.second = _new_weights_addr[1];
+    grads[_gradient_id].new_model_error = _new_model_error;
+
+    //transferAmount(grads[_gradient_id].from,1);
+
     Model model = models[grads[_gradient_id].model_id];
-    if(grads[_gradient_id].evaluated == false) {
+    if(_new_model_error < model.best_error) {
+      uint incentive = ((model.best_error - _new_model_error) * model.bounty) / model.best_error;
 
-      grads[_gradient_id].new_weights.first = _new_weights_addr[0];
-      grads[_gradient_id].new_weights.second = _new_weights_addr[1];
-      grads[_gradient_id].new_model_error = _new_model_error;
-
-      
-      //transferAmount(grads[_gradient_id].from,1);
-
-      if(_new_model_error < model.best_error) {
-        uint incentive = ((model.best_error - _new_model_error) * model.bounty) / model.best_error;
-
-        model.best_error = _new_model_error;
-        model.weights = grads[_gradient_id].new_weights;
-        transferAmount(grads[_gradient_id].from, incentive);
-      }
-
-      grads[_gradient_id].evaluated = true;
+      model.best_error = _new_model_error;
+      model.weights = grads[_gradient_id].new_weights;
+      transferAmount(grads[_gradient_id].from, incentive);
     }
+
+    grads[_gradient_id].evaluated = true;
   }
 
   function addGradient(uint model_id, bytes32[] _grad_addr) {

--- a/test/modelrepository.js
+++ b/test/modelrepository.js
@@ -24,6 +24,11 @@ const firstGradient = {
   twoPartIpfsHash: splitIpfsHashInMiddle('QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG')
 }
 
+const secondGradient = {
+  id: 0,
+  twoPartIpfsHash: splitIpfsHashInMiddle('QmVLDAhCY3X9P2uRudKAryuQFPM5zqA3Yij1dY8FpGbL7T')
+}
+
 const addFirstModel = async (modelRepositoryContract, modelOwner) => {
   modelRepositoryContract.addModel(firstModel.twoPartIpfsHash, firstModel.initialError, firstModel.targetError, {
     from: modelOwner,
@@ -97,6 +102,8 @@ contract('ModelRepository', accounts => {
 contract('ModelRepository - Evaluating Gradients', accounts => {
   const oscarTheModelOwner = accounts[0]
   const patTheGradientProvider = accounts[1]
+  const gregTheGradientProvider = accounts[2]
+
 
   it('will not evaluate the same gradient twice', async () => {
     const modelRepositoryContract = await ModelRepository.deployed()
@@ -143,4 +150,24 @@ contract('ModelRepository - Evaluating Gradients', accounts => {
     assert.ok(balanceAfterEvaluation.valueOf() > balanceBeforeEvaluation.valueOf(),
       'gradient provider was paid')
   })
+
+  it('will only allow the model owner to evaluate a gradient', async () => {
+    const modelRepositoryContract = await ModelRepository.deployed()
+    await modelRepositoryContract.addGradient(firstModel.id, secondGradient.twoPartIpfsHash, {
+      from: gregTheGradientProvider
+    })
+
+    const improvedError = firstModel.initialError - 2
+    const updatedWeights = splitIpfsHashInMiddle('QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG')
+    try {
+      await modelRepositoryContract.evalGradient(firstGradient.id + 1, improvedError, updatedWeights, {
+        from: gregTheGradientProvider
+      })
+    } catch (error) {
+      assert.ok(error)
+      return
+    }
+    assert.fail()
+  })
+
 })

--- a/test/modelrepository.js
+++ b/test/modelrepository.js
@@ -116,21 +116,16 @@ contract('ModelRepository - Evaluating Gradients', accounts => {
       from: oscarTheModelOwner
     })
     const newErrorAttempt = 2
-    const evaluatedGradient = await getFirstGradient(modelRepositoryContract)
     const secondAttemptWeights = splitIpfsHashInMiddle('QmYwARJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG')
-    await modelRepositoryContract.evalGradient(firstGradient.id, newErrorAttempt, secondAttemptWeights, {
-      from: oscarTheModelOwner
-    })
-    const evaluatedGradientAfterSecondAttempt = await getFirstGradient(modelRepositoryContract)
-
-    assert.equal(evaluatedGradient[3], errorWorseThanInitial, 'new error set after first attempt')
-    assert.equal(hexToString(evaluatedGradient[4][0]), firstGradient.twoPartIpfsHash[0], 'ipfshash persisted')
-    assert.equal(hexToString(evaluatedGradient[4][1]), firstGradient.twoPartIpfsHash[1], 'ipfshash persisted')
-    assert.equal(evaluatedGradientAfterSecondAttempt[3], errorWorseThanInitial, 'error not updated during second attempt')
-    assert.equal(hexToString(evaluatedGradientAfterSecondAttempt[4][0]), firstGradient.twoPartIpfsHash[0],
-      'weights not updated during second attempt')
-    assert.equal(hexToString(evaluatedGradientAfterSecondAttempt[4][1]), firstGradient.twoPartIpfsHash[1],
-      'weights not updated during second attempt')
+    try {
+      await modelRepositoryContract.evalGradient(firstGradient.id, newErrorAttempt, secondAttemptWeights, {
+        from: oscarTheModelOwner
+      })
+    } catch (error) {
+      assert.ok(error)
+      return
+    }
+    assert.fail()
   })
 
   it('pays a bounty if new error is less than best error', async () => {

--- a/test/modelrepository.js
+++ b/test/modelrepository.js
@@ -104,7 +104,6 @@ contract('ModelRepository - Evaluating Gradients', accounts => {
   const patTheGradientProvider = accounts[1]
   const gregTheGradientProvider = accounts[2]
 
-
   it('will not evaluate the same gradient twice', async () => {
     const modelRepositoryContract = await ModelRepository.deployed()
     await addFirstModel(modelRepositoryContract, oscarTheModelOwner)
@@ -164,5 +163,4 @@ contract('ModelRepository - Evaluating Gradients', accounts => {
     }
     assert.fail()
   })
-
 })


### PR DESCRIPTION
Using the modifiers every ethereum-client will tell the caller, during the local evaluation (not yet broadcasting it to the network), _"Hey if you call this method it will fail, please don't waste the transaction costs for a failing transaction"_. Until now the call led to a transaction that did nothing but was still broadcasted and required transaction fees.