### PR TITLE
Fix issue 38

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@
 <!-- TOC depthFrom:2 -->
 
 - [Setup](#setup)
-    - [Prerequisites](#prerequisites)
-    - [Installation](#installation)
+    - [Using Docker](#using-docker)
 - [Usage](#usage)
     - [Bootstrap environment](#bootstrap-environment)
     - [Start](#start)
@@ -24,19 +23,13 @@ You can find a working proof of concept in the [notebooks](./notebooks) director
 
 ## Setup
 
-### Prerequisites
+### Using Docker
 
-Using Docker is the easiest way to get this running.
+Using [Docker](https://www.docker.com) is the easiest way to get this running.
 
-* Install Docker from [its website](https://www.docker.com/)
-* For macOS users install from [here](https://docs.docker.com/docker-for-mac/)
-
-### Installation
-
-1. Run `docker-compose up`
-2. Look for the Jupyter notebook URL, it should look like `http://0.0.0.0:8888/?token=<long token here>` - open that URL in your web browser
-3. When running the notebooks, search the verbose output of the `docker-compose up` command for the `eth_getCode` -> `ModelRepository` address and copy into the last line of the cell under "Setting up the Experiment" as explained in the "ATTENTION" comment 🙂
-4. Step through the notebook
+1. Run `docker-compose up`. This will launch IPFS, the in-memory fake ethereum blockchain with the smart contract, [OpenMined mine.js](https://github.com/OpenMined/mine.js) and the jupyter notebooks
+2. Open the the Jupyter notebooks on [http://localhost:8888](http://localhost:8888)
+3. Step through the notebook and check the output of the previous `docker-compose up` to get some infos on what happens
 
 ## Usage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,16 @@
-version: '2'
+version: '3'
 services:
-  testrpc:
-    image: "harshjv/testrpc:latest"
-    command: ["-a", "1000", "-i", "25189"]
   ipfs:
-    image: "ipfs/go-ipfs:latest"
-    links:
-      - testrpc
-  sonar:
-    image: "openmined/sonar:latest"
-    links:
-      - testrpc
-    command: /bin/sh -c "sleep 10 && truffle migrate --network docker"
-  pysonar-notebooks:
+    image: ipfs/go-ipfs:latest
+  testrpc:
+    image: openmined/sonar-testrpc:hydrogen
+    command: ./node_modules/.bin/testrpc --host 0.0.0.0 --db "/data/testrpc_persist" --seed "20170812" --accounts 42
+  mine:
+    image: openmined/mine.js:hydrogen
+    command: ./node_modules/.bin/nodemon bin/cli.js train --mine-address auto --contract-address 0x249c008fc4f9c01248f557985f5b5b1aed8eb98f --ethereum-url http://testrpc:8545 --ipfs-url http://ipfs:5001
+    depends_on: [testrpc]
+  notebook:
     build:
       context: .
       dockerfile: Dockerfile.notebooks
-    volumes:
-      - ./notebooks:/notebooks
-    ports:
-      - 8888:8888
-    links:
-      - ipfs
-      - testrpc
+    ports: ["8888:8888"]

--- a/sonar/ipfs.py
+++ b/sonar/ipfs.py
@@ -3,10 +3,14 @@ import ipfsapi
 
 class IPFS:
     def __init__(self, host='127.0.0.1', port=5001):
-        self.ipfs = ipfsapi.connect(host, int(port))
+        self.host = host
+        self.port = int(port)
+
+    def connect(self):
+        return ipfsapi.connect(self.host, self.port)
 
     def store(self, obj):
-        return self.ipfs.add_pyobj(obj)
+        return self.connect().add_pyobj(obj)
 
-    def retrieve(self, hash):
-        return self.ipfs.get_pyobj(hash)
+    def retrieve(self, ipfs_hash):
+        return self.connect().get_pyobj(ipfs_hash)


### PR DESCRIPTION
fixes #38 and fixes #12 

updates the `docker-compose.yml` to use version 3. the contents were mostly taken from https://github.com/OpenMined/mine.js/blob/master/.docker/docker-compose.yml. I left the unnecessary parts such as `network`, which is not necessary if every container is using the same network. It uses the local `Dockerfile.notebooks` instead of the image on dockerhub so users can quickly learn if they break something.