### PR TITLE
Incentive should consider 'target_error' for incentive calculation

### DIFF
--- a/test/TestModelRepository.sol
+++ b/test/TestModelRepository.sol
@@ -14,4 +14,14 @@ contract TestModelRepository {
     Assert.equal(repo.getNumModels(), initialModelsAmount, "ModelRepository holds 0 models initially");
   }
 
+  function testIncentiveValue() {
+    ModelRepository repo = new ModelRepository();
+
+    //total error = initial error - target_error
+    //solved error = best_error - _new_model_error
+    //incentiveCalculate(bounty, total_error, solved_error)
+
+    Assert.equal(repo.incentiveCalculate(3000000000000000000, 500, 10), 60000000000000000);
+    Assert.equal(repo.incentiveCalculate(123456789, 12, 4), 41152263);
+  }
 }


### PR DESCRIPTION
Given incentive calculation is  not accurate because it is calculating the incentive without considering 'Model.target_error'.  Its assumes the target_error =0. 
New calculation considers the 'target_error' and gets incentive.