### PR TITLE
Corrected incentive calculation

### DIFF
--- a/contracts/ModelRepository.sol
+++ b/contracts/ModelRepository.sol
@@ -90,7 +90,7 @@ contract ModelRepository {
     if(_new_model_error < model.best_error) {
       uint total_error= model.initial_error - model.target_error;
       uint solved_error= model.best_error - _new_model_error;
-      incentive = incentiveCalculate(model.bounty, total_error, solved_error);
+      uint incentive = incentiveCalculate(model.bounty, total_error, solved_error);
 
       model.best_error = _new_model_error;
       model.weights = grads[_gradient_id].new_weights;

--- a/test/TestModelRepository.sol
+++ b/test/TestModelRepository.sol
@@ -14,4 +14,14 @@ contract TestModelRepository {
     Assert.equal(repo.getNumModels(), initialModelsAmount, "ModelRepository holds 0 models initially");
   }
 
+  function testIncentiveValue() {
+    ModelRepository repo = new ModelRepository();
+
+    //total error = initial error - target_error
+    //solved error = best_error - _new_model_error
+    //incentiveCalculate(bounty, total_error, solved_error)
+
+    Assert.equal(repo.incentiveCalculate(3000000000000000000, 500, 10), 60000000000000000);
+    Assert.equal(repo.incentiveCalculate(123456789, 12, 4), 41152263);
+  }
 }


### PR DESCRIPTION
the incentive calculation is  not accurate because it is calculating the incentive without considering 'Model.target_error'.  Its assumes the target_error =0.
new calculation considering the 'target_error'