### PR TITLE
Refactor Dockerfile to use multi-stage builds to decrease resulting i…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,57 @@
-FROM openmined/pysyft:hydrogen
-RUN ["apk", "add", "--no-cache", "python3", "python3-dev", "musl-dev", "linux-headers", "g++", "lapack-dev", "gfortran", "gmp-dev", "mpfr-dev", "mpc1-dev", "make"]
+# This Dockerfile uses Docker Multi-Stage Builds
+# See https://docs.docker.com/engine/userguide/eng-image/multistage-build/
 
-RUN ["mkdir", "/pysonar"]
+### Base Image
+# Setup up a base image to use in build and runtime images
+FROM openmined/pysyft:hydrogen AS base
+
+EXPOSE 8888
+CMD ["jupyter", "notebook", "--config=./jupyter_notebook_config.py", "--allow-root"]
+
+# Intermediate build container
+FROM base AS build
+WORKDIR /pysonar
+
+# Install build OS packages
+RUN apk add --no-cache \
+            python3 \
+            python3-dev \
+            alpine-sdk \
+            nodejs \
+            nodejs-npm \
+            git \
+            linux-headers \
+            lapack-dev \
+            gfortran \
+            gmp-dev \
+            gmp-dev \
+            mpfr-dev \
+            mpc1-dev
+
+#Pysonar image
+FROM build AS pysonar
+
+# Setup workdir and copy requirements file
 COPY requirements.txt /pysonar
-RUN ["pip3", "install", "numpy"]
-RUN ["pip3", "install", "scipy"]
+
+# Install python packages
+RUN ["pip3", "install", "numpy", "scipy"]
 RUN ["pip3", "install", "-r", "/pysonar/requirements.txt"]
 
 # install pySonar lib
 COPY . /pysonar
-WORKDIR /pysonar
 RUN ["python3", "setup.py", "install"]
 
-# copy notebook code
+# import abi via NPM module
+RUN ["make", "import-abi"]
+
+# Runtime image
+FROM base AS runtime
+WORKDIR /notebooks
+
 RUN ["pip3", "install", "jupyter", "notebook"]
-RUN ["mkdir", "/notebooks"]
 COPY notebooks /notebooks
 COPY jupyter_notebook_config.py /notebooks/
 
-# import abi via NPM module
-RUN apk add --update nodejs nodejs-npm git && \
-    make import-abi && \
-    cp -r /pysonar/abis /abis
-
-WORKDIR /notebooks
-EXPOSE 8888
-CMD ["jupyter", "notebook", "--config=./jupyter_notebook_config.py", "--allow-root"]
+# Copy artifacts from pysonar image
+COPY --from=pysonar /pysonar/ /pysonar/


### PR DESCRIPTION
…mage size - fixes #35. Requires Docker 17.06+ to build.

Original `Dockerfile` image size was **643MB**

```
pysonar                                        original            2289662e0c9b        About an hour ago   643MB
```

Refactored multi-stage image is **382MB**

```
pysonar                                        refactor            be1ddac7e9c9        31 minutes ago      382MB
```

Tested locally with docker-compose and application seems to run the same.