### PR TITLE
Exclude testRPC from docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:alpine
-RUN ["npm", "install", "-g", "truffle"]
+RUN ["npm", "install", "-g", "truffle@^4.0.4"]
 COPY . /sonar
 WORKDIR /sonar
 RUN ["truffle", "compile"]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ We prepared a Docker container of the Sonar smart contract running on a private 
 Run
 
 ```sh
-docker run -d -p 8545:8545 openmined/sonar-testrpc:edge
+docker run -d -p 8545:8545 openmined/sonar:edge
 # :edge for the latest dev build
 # :latest (default) for stable builds
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ We prepared a Docker container of the Sonar smart contract running on a private 
 Run
 
 ```sh
-docker run -d -p 8545:8545 openmined/sonar:edge
+docker run -d -p 9545:9545 openmined/sonar:edge
 # :edge for the latest dev build
 # :latest (default) for stable builds
 ```


### PR DESCRIPTION
after PR#50 we only use sonar docker moving forward.
also added specific truffle number to dockerfile.