### PR TITLE
update output path to reflect new truffle build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,4 @@ test:
 
 import-abi:
 	npm install && \
-	cp node_modules/@openmined/sonar/build/*.abi abis/
+	cp node_modules/@openmined/sonar/build/contracts/*.abi abis/


### PR DESCRIPTION
truffle build will output all `abi` contracts into `/build/contracts` path. this will reflect the change.
related to - https://github.com/OpenMined/Sonar/pull/54